### PR TITLE
Bump upper bound of hpc to 0.8

### DIFF
--- a/hpc-lcov.cabal
+++ b/hpc-lcov.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
       base >=4.9 && <5
     , containers >=0.5.7.1 && <0.7
-    , hpc >=0.6.0.3 && <0.7
+    , hpc >=0.6.0.3 && <0.8
   default-language: Haskell2010
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
@@ -55,7 +55,7 @@ executable hpc-lcov
       aeson >=1.5.5.1 && <3
     , base >=4.9 && <5
     , containers >=0.5.7.1 && <0.7
-    , hpc >=0.6.0.3 && <0.7
+    , hpc >=0.6.0.3 && <0.8
     , hpc-lcov
     , optparse-applicative >=0.15.1.0 && <0.19
     , path >=0.7.0 && <0.10
@@ -85,7 +85,7 @@ test-suite hpc-lcov-test
   build-depends:
       base >=4.9 && <5
     , containers >=0.5.7.1 && <0.7
-    , hpc >=0.6.0.3 && <0.7
+    , hpc >=0.6.0.3 && <0.8
     , hpc-lcov
     , tasty
     , tasty-discover


### PR DESCRIPTION
I recently released a new major version of hpc: 0.7.0.0. The only significant difference is that hpc has dropped all promises about safe/trustworthy Haskell. This is due to the fact that we depend on the directory package which recently dropped its SafeHaskell promises.
If you don't use SafeHaskell then you shouldn't notice a difference, except that we are now compatible with newer versions of the directory package.